### PR TITLE
Backdate test dependencies to 1.0 standard versions

### DIFF
--- a/test/Microsoft.AspNetCore.Server.WebListener.FunctionalTests/project.json
+++ b/test/Microsoft.AspNetCore.Server.WebListener.FunctionalTests/project.json
@@ -5,10 +5,10 @@
   },
   "testRunner": "xunit",
   "dependencies": {
-    "dotnet-test-xunit": "2.2.0-*",
+    "dotnet-test-xunit": "1.0.0-rc3-000000-01",
     "Microsoft.AspNetCore.Server.WebListener": "1.0.0",
-    "Microsoft.AspNetCore.Testing": "1.0.0",
-    "xunit": "2.2.0-*"
+    "Microsoft.AspNetCore.Testing": "1.0.0-rtm-21431",
+    "xunit": "2.1.0"
   },
   "frameworks": {
     "netcoreapp1.0": {

--- a/test/Microsoft.Net.Http.Server.FunctionalTests/project.json
+++ b/test/Microsoft.Net.Http.Server.FunctionalTests/project.json
@@ -1,10 +1,10 @@
 {
   "testRunner": "xunit",
   "dependencies": {
-    "dotnet-test-xunit": "2.2.0-*",
+    "dotnet-test-xunit": "1.0.0-rc3-000000-01",
     "Microsoft.Net.Http.Server": "1.0.0",
-    "Microsoft.AspNetCore.Testing": "1.0.0",
-    "xunit": "2.2.0-*"
+    "Microsoft.AspNetCore.Testing": "1.0.0-rtm-21431",
+    "xunit": "2.1.0"
   },
   "frameworks": {
     "netcoreapp1.0": {

--- a/test/Microsoft.Net.Http.Server.Tests/project.json
+++ b/test/Microsoft.Net.Http.Server.Tests/project.json
@@ -1,9 +1,9 @@
 ﻿{
   "testRunner": "xunit",
   "dependencies": {
-    "dotnet-test-xunit": "2.2.0-*",
+    "dotnet-test-xunit": "1.0.0-rc3-000000-01",
     "Microsoft.Net.Http.Server": "1.0.0",
-    "xunit": "2.2.0-*"
+    "xunit": "2.1.0"
   },
   "frameworks": {
     "netcoreapp1.0": {


### PR DESCRIPTION
@pranavkm 

Compare to https://github.com/aspnet/KestrelHttpServer/blob/rel/1.0.1/test/Microsoft.AspNetCore.Server.Kestrel.FunctionalTests/project.json