### PR TITLE
Add imports required for tests

### DIFF
--- a/test/Microsoft.AspNetCore.Server.WebListener.FunctionalTests/project.json
+++ b/test/Microsoft.AspNetCore.Server.WebListener.FunctionalTests/project.json
@@ -21,7 +21,11 @@
         "System.Net.Requests": "4.0.11-*",
         "System.Net.WebHeaderCollection": "4.0.1-*",
         "System.Net.WebSockets.Client": "4.0.0"
-      }
+      },
+      "imports": [
+        "dnxcore50",
+        "portable-net451+win8"
+      ]
     },
     "net451": {
       "frameworkAssemblies": {

--- a/test/Microsoft.Net.Http.Server.FunctionalTests/project.json
+++ b/test/Microsoft.Net.Http.Server.FunctionalTests/project.json
@@ -17,7 +17,11 @@
         "System.Net.Http.WinHttpHandler": "4.0.0-*",
         "System.Net.Requests": "4.0.11-*",
         "System.Net.WebSockets.Client": "4.0.0-*"
-      }
+      },
+      "imports": [
+        "dnxcore50",
+        "portable-net451+win8"
+      ]
     },
     "net451": {
       "frameworkAssemblies": {

--- a/test/Microsoft.Net.Http.Server.Tests/project.json
+++ b/test/Microsoft.Net.Http.Server.Tests/project.json
@@ -12,7 +12,11 @@
           "version": "1.0.0",
           "type": "platform"
         }
-      }
+      },
+      "imports": [
+        "dnxcore50",
+        "portable-net451+win8"
+      ]
     },
     "net451": {}
   }


### PR DESCRIPTION
Test projects need imports. This was causing the patch release builds to fail.

FYI @pranavkm @Tratcher Merging now to unblock.