### PR TITLE
Disable parallel test execution to improve reliability

### DIFF
--- a/test/Microsoft.AspNetCore.Server.HttpSys.FunctionalTests/Properties/AssemblyInfo.cs
+++ b/test/Microsoft.AspNetCore.Server.HttpSys.FunctionalTests/Properties/AssemblyInfo.cs
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using Microsoft.AspNetCore.Testing.xunit;
+using Xunit;
 
 [assembly: OSSkipCondition(OperatingSystems.MacOSX)]
 [assembly: OSSkipCondition(OperatingSystems.Linux)]
+[assembly: CollectionBehavior(DisableTestParallelization = true)]


### PR DESCRIPTION
As a side effect of merging test projects, there are now sets of similar tests executing in parallel and causing conflicts, especially for things like caching. For now I'm disabling parallel test execution and we can iron out the conflicts later.
#263 